### PR TITLE
Update formula to new Homebrew syntax and dependencies

### DIFF
--- a/elasticsearch@1.7.rb
+++ b/elasticsearch@1.7.rb
@@ -9,7 +9,7 @@ class ElasticsearchAT17 < Formula
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.7+"
+  depends_on "java8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -67,7 +67,7 @@ class ElasticsearchAT17 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -77,7 +77,7 @@ class ElasticsearchAT17 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch@1.7/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">

--- a/pingboard-dev-workflow.rb
+++ b/pingboard-dev-workflow.rb
@@ -6,21 +6,21 @@ class PingboardDevWorkflow < Formula
   sha256 '898b1e5849d3866a74e4cbf6b63cd9d4af192c02a82b73a9d6942f95a3573201'
 
   depends_on 'git-flow-avh'
-  depends_on 'pivotal-tracker' => :ruby
+  depends_on 'pivotal-tracker'
   depends_on 'phantomjs'
   depends_on 'postgresql'
   depends_on 'redis'
   depends_on 'elasticsearch'
-  depends_on 'overcommit' => :ruby
-  depends_on 'bundler' => :ruby
-  
+  depends_on 'overcommit'
+  depends_on 'bundler'
+
   def install
     bin.install 'git-pivotal'
     share.install 'hooks'
   end
 
   def caveats
-    s = <<-EOS.undent
+    <<-EOS
       Add your personal pivotal token and the Pingboard project id to the git config
 
         git config --add pivotal.token PIVOTAL_TOKEN


### PR DESCRIPTION
- have to use caskroom/versions for Java versions now (specifically, 8)
- couldn't upgrade to Java 10 because a GC paramter name was removed
- fix deprecated style of `depends_on` usage
- fix Ruby warnings